### PR TITLE
fix korean in `rewriting-history.asc`

### DIFF
--- a/book/07-git-tools/sections/rewriting-history.asc
+++ b/book/07-git-tools/sections/rewriting-history.asc
@@ -81,14 +81,14 @@ Rebase와 같이 이미 Push 한 커밋은 수정하면 안 된다.
 //////////////////////////
 .An amended commit may (or may not) need an amended commit message
 //////////////////////////
-.커밋을 고치는 작업은 커밋 메시지 고치를 덩달아 이끌 수 있음
+.커밋을 고치는 작업은 커밋 메시지 수정을 야기할 수 있음.
 ====
 //////////////////////////
 When you amend a commit, you have the opportunity to change both the commit message and the content of the commit.
 If you amend the content of the commit substantially, you should almost certainly update the commit message to reflect that amended content.
 //////////////////////////
-커밋을 고치는 것은 커밋 메시지를 고치는 것일수도 있고 또는 커밋 담고 있는 변경 내용을 고치는 것 일수도 있다.
-커밋의 고치는데 있어 추가된 변경 내용이 상당히 있을 경우 커밋 메시지가 충실하게 담고 있는지 확인해 볼 필요가 있다.
+커밋을 고치는 것은 커밋 메시지를 고치는 것일수도 있고 또는 커밋을 담고 있는 변경 내용을 고치는 것 일수도 있다.
+커밋 내용을 고치는데 있어 추가된 변경 내용이 상당히 있을 경우 커밋 메시지가 수정 내용을 충실하게 담고 있는지 확인해 볼 필요가 있다.
 
 //////////////////////////
 On the other hand, if your amendments are suitably trivial (fixing a silly typo or adding a file you forgot to stage) such that the earlier commit message is just fine, you can simply make the changes, stage them, and avoid the unnecessary editor session entirely with:


### PR DESCRIPTION
`7.6 Git 도구 - 히스토리 단장하기` 챕터(file: `rewriting-history.asc`)의 오타 및 매끄럽지 못한 한국어를 수정하였습니다.